### PR TITLE
fix(onc-flight-itinerary-info-popover): fix popover close click handl…

### DIFF
--- a/packages/ui-components/src/components/flight-itinerary-info-popover/flight-itinerary-info-popover.tsx
+++ b/packages/ui-components/src/components/flight-itinerary-info-popover/flight-itinerary-info-popover.tsx
@@ -82,7 +82,10 @@ export class FlightItineraryInfoPopover {
   @State() isVisible = false;
 
   @Listen("click", {
-    target: "window",
+    // Use body instead of window as the click event handler's target,
+    // because on ios safari the events are not fired on window but on
+    // body they work.
+    target: "body",
   })
   onClick(e: MouseEvent) {
     this.triggerEl = this.getTriggerElement();


### PR DESCRIPTION
…er not working on ios safari

ios safari's click event handler doesn't fire if it is attached to window, but does work when it is
attached to body.