### PR TITLE
fix(onc-flight-itinerary-info-popover): use capture click event liste…

### DIFF
--- a/packages/ui-components/src/utils/assert.ts
+++ b/packages/ui-components/src/utils/assert.ts
@@ -1,0 +1,11 @@
+export class AssertionError extends Error {
+  constructor(msg: string) {
+    super(msg);
+  }
+}
+
+export function assert(condition: boolean, msg?: string) {
+  if (!condition) {
+    throw new AssertionError(msg ?? "Assertion failed");
+  }
+}


### PR DESCRIPTION
…ner to close the popover

The popover should be closed when user clicks outside of it. Some sites may prevent click event
propagating to the body. To overcome this, we use capture click handler to handle closing of the
popover.